### PR TITLE
Let's depend on rake 11

### DIFF
--- a/alexa_rubykit.gemspec
+++ b/alexa_rubykit.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
   spec.add_runtime_dependency 'bundler', '~> 1.7'
-  spec.add_runtime_dependency 'rake', '~> 10.0'
+  spec.add_runtime_dependency 'rake', '~> 11.0'
   spec.add_development_dependency 'rspec', '~> 3.2', '>= 3.2.0'
   spec.add_development_dependency 'rspec-mocks', '~> 3.2', '>= 3.2.0'
 end


### PR DESCRIPTION
Let's update rake dependency to 11 version to prevent conflicts with other gems depending on latest rake.