### PR TITLE
Fix AWS request validations which are always validating true

### DIFF
--- a/lib/alexa_rubykit.rb
+++ b/lib/alexa_rubykit.rb
@@ -18,7 +18,7 @@ module AlexaRubykit
 
   # Returns true if all the Alexa request objects are set.
   def self.valid_alexa?(request_json)
-    !request_json.nil? || !request_json['session'].nil? ||
-        !request_json['version'].nil? || !request_json['request'].nil?
+    !request_json.nil? && !request_json['session'].nil? &&
+        !request_json['version'].nil? && !request_json['request'].nil?
   end
 end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -19,9 +19,9 @@ describe 'Request handling' do
 
   it 'should raise an exception when an invalid request is sent' do
     sample_request = 'invalid object!'
-    expect { AlexaRubykit::build_request(sample_request)}.to raise_exception
+    expect { AlexaRubykit::build_request(sample_request)}.to raise_error(ArgumentError)
     sample_request = nil
-    expect { AlexaRubykit::build_request(sample_request)}.to raise_exception
+    expect { AlexaRubykit::build_request(sample_request)}.to raise_error(ArgumentError)
   end
 
   it 'should create valid intent request type' do

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -9,6 +9,14 @@ describe 'Request handling' do
     expect(request.type).to eq('LAUNCH_REQUEST')
   end
 
+  it 'should correctly identify valid AWS requests' do
+    sample_bad_request = { foo: 'bar' }
+    expect(AlexaRubykit::valid_alexa?(sample_bad_request)).to be false
+
+    sample_good_request = JSON.parse(File.read('fixtures/sample-IntentRequest.json'))
+    expect(AlexaRubykit::valid_alexa?(sample_good_request)).to be true
+  end
+
   it 'should raise an exception when an invalid request is sent' do
     sample_request = 'invalid object!'
     expect { AlexaRubykit::build_request(sample_request)}.to raise_exception


### PR DESCRIPTION
The `AlexaRubyKit::valid_alexa?` implementation was broken, and failing open due to a glitch in the boolean logic. This addresses that bug, and adds a specific test for it.

The bug was a bit obscured in the `should raise an exception when an invalid request is sent` test, because it was matching on any error — in this case, `#<NoMethodError: undefined method `[]' for nil:NilClass>` was firing and passing the test.

Rspec was raising a warning about the unclear matching, which this also addresses.

> WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<NoMethodError: undefined method `[]' for nil:NilClass>. Instead consider providing a specific error class or message.