### PR TITLE
Add ssml support

### DIFF
--- a/lib/alexa_rubykit/response.rb
+++ b/lib/alexa_rubykit/response.rb
@@ -16,8 +16,12 @@ module AlexaRubykit
       @session_attributes[key.to_sym] = value
     end
 
-    def add_speech(speech_text)
-      @speech = { :type => 'PlainText', :text => speech_text }
+    def add_speech(speech_text, ssml = false)
+      if ssml
+        @speech = { :type => 'SSML', :ssml => check_ssml(speech_text) }
+      else
+        @speech = { :type => 'PlainText', :text => speech_text }
+      end
       @speech
     end
     
@@ -35,8 +39,12 @@ module AlexaRubykit
       }
     end
 
-    def add_reprompt(speech_text)
-      @reprompt = { "outputSpeech" => { :type => 'PlainText', :text => speech_text } }
+    def add_reprompt(speech_text, ssml = false)
+      if ssml
+        @reprompt = { "outputSpeech" => { :type => 'SSML', :ssml => check_ssml(speech_text) } }
+      else
+        @reprompt = { "outputSpeech" => { :type => 'PlainText', :text => speech_text } }
+      end
       @reprompt
     end
 
@@ -63,15 +71,15 @@ module AlexaRubykit
     end
 
     # Adds a speech to the object, also returns a outputspeech object.
-    def say_response(speech, end_session = true)
-      output_speech = add_speech(speech)
+    def say_response(speech, end_session = true, ssml = false)
+      output_speech = add_speech(speech,ssml)
       { :outputSpeech => output_speech, :shouldEndSession => end_session }
     end
 
     # Incorporates reprompt in the SDK 2015-05
-    def say_response_with_reprompt(speech, reprompt_speech, end_session = true)
-      output_speech = add_speech(speech)
-      reprompt_speech = add_reprompt(reprompt_speech)
+    def say_response_with_reprompt(speech, reprompt_speech, end_session = true, speech_ssml = false, reprompt_ssml = false)
+      output_speech = add_speech(speech,speech_ssml)
+      reprompt_speech = add_reprompt(reprompt_speech,reprompt_ssml)
       { :outputSpeech => output_speech, :reprompt => reprompt_speech, :shouldEndSession => end_session }
     end
 
@@ -112,5 +120,12 @@ module AlexaRubykit
     def to_s
       "Version => #{@version}, SessionObj => #{@session}, Response => #{@response}"
     end
+
+    private
+
+      def check_ssml(ssml_string)
+        ssml_string = ssml_string.strip[0..6] == "<speak>" ? ssml_string : "<speak>" + ssml_string
+        ssml_string.strip[-8..1] == "</speak>" ? ssml_string : ssml_string + "</speak>"
+      end
   end
 end

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -75,6 +75,7 @@ describe 'Builds appropriate response objects' do
     expect(response_object[:outputSpeech][:type]).to include('SSML')
     expect(response_object[:outputSpeech][:ssml]).to include('<speak>')
     expect(response_object[:outputSpeech][:ssml]).to include('</speak>')
+    expect(response_object[:outputSpeech][:ssml]).to include('<speak>Testing SSML Alexa Rubykit support!</speak>')
   end
 
   it 'should create a valid minimum response (body)' do

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -28,6 +28,7 @@ describe 'Builds appropriate response objects' do
     response.add_speech('Testing Alexa Rubykit!')
     response_object = response.build_response_object
     expect(response_object).to include(:outputSpeech)
+    expect(response_object[:outputSpeech][:type]).to include('PlainText')
     expect(response_object[:outputSpeech][:text]).to include('Testing Alexa Rubykit!')
 
     # The say_response command should create the same object.
@@ -42,6 +43,38 @@ describe 'Builds appropriate response objects' do
     expect(response_object[:shouldEndSession]).to eq(false)
     # say_response should now be NOT equal thanks to endsession.
     expect(response_say_object).not_to eq(response_object)
+  end
+
+  it 'should create a valid SSML Alexa say response object' do
+    response = AlexaRubykit::Response.new
+    response.add_speech('<speak>Testing SSML Alexa Rubykit support!</speak>',true)
+    response_object = response.build_response_object
+    expect(response_object).to include(:outputSpeech)
+    expect(response_object[:outputSpeech][:type]).to include('SSML')
+    expect(response_object[:outputSpeech][:ssml]).to include('<speak>Testing SSML Alexa Rubykit support!</speak>')
+
+    # The say_response command should create the same object.
+    response_say = AlexaRubykit::Response.new
+    response_say_object = response_say.say_response('<speak>Testing SSML Alexa Rubykit support!</speak>',true,true)
+    expect(response_say_object).to eq(response_object)
+
+    # End session should be true if we didn't specify it.
+    expect(response_object[:shouldEndSession]).to eq(true)
+    response_object = response.build_response_object(false)
+    # And to be false if we tell it to continue the session
+    expect(response_object[:shouldEndSession]).to eq(false)
+    # say_response should now be NOT equal thanks to endsession.
+    expect(response_say_object).not_to eq(response_object)
+  end
+
+  it 'should create a valid SSML Alexa say response object when ssml lacks speak tags' do
+    response = AlexaRubykit::Response.new
+    response.add_speech('Testing SSML Alexa Rubykit support!',true)
+    response_object = response.build_response_object
+    expect(response_object).to include(:outputSpeech)
+    expect(response_object[:outputSpeech][:type]).to include('SSML')
+    expect(response_object[:outputSpeech][:ssml]).to include('<speak>')
+    expect(response_object[:outputSpeech][:ssml]).to include('</speak>')
   end
 
   it 'should create a valid minimum response (body)' do


### PR DESCRIPTION
Adding SSML support as per:
https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/speech-synthesis-markup-language-ssml-reference

Will wrap any response text that does not have the proper formatting (<speak> tags) with the proper formatting.

All tests are passing.
Tested the PR on my project and did not experience any issues and worked as intended.