### PR TITLE
Added support for dialog delegation

### DIFF
--- a/lib/alexa_rubykit/response.rb
+++ b/lib/alexa_rubykit/response.rb
@@ -39,6 +39,12 @@ module AlexaRubykit
       }
     end
 
+    def delegate_dialog_response
+      @directives << {
+        'type'=> 'Dialog.Delegate'
+      }
+    end
+
     def add_reprompt(speech_text, ssml = false)
       if ssml
         @reprompt = { "outputSpeech" => { :type => 'SSML', :ssml => check_ssml(speech_text) } }
@@ -82,7 +88,6 @@ module AlexaRubykit
       reprompt_speech = add_reprompt(reprompt_speech,reprompt_ssml)
       { :outputSpeech => output_speech, :reprompt => reprompt_speech, :shouldEndSession => end_session }
     end
-
 
     # Creates a session object. We pretty much only use this in testing.
     def build_session

--- a/lib/alexa_rubykit/response.rb
+++ b/lib/alexa_rubykit/response.rb
@@ -10,11 +10,11 @@ module AlexaRubykit
 
     # Every response needs a shouldendsession and a version attribute
     # We initialize version to 1.0, use add_version to set your own.
-    def initialize(version = '1.0', request)
+    def initialize(request=nil, version='1.0')
       @session_attributes = Hash.new
       @version = version
       @request = request
-      @intents = request.intent if request.type == "INTENT_REQUEST"
+      @intents = request.intent if request && request.type == "INTENT_REQUEST"
       @directives = []
     end
 

--- a/lib/alexa_rubykit/response/dialog.rb
+++ b/lib/alexa_rubykit/response/dialog.rb
@@ -1,0 +1,42 @@
+module AlexaRubykit
+  # Represents the encapsulation of Amazon Alexa Dialog Interface
+  # https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/dialog-interface-reference
+  class Dialog
+    DELEGATE_TYPE       = "Dialog.Delegate".freeze
+    ELICIT_SLOT_TYPE    = "Dialog.ElicitSlot".freeze
+    CONFIRM_SLOT_TYPE   = "Dialog.ConfirmSlot".freeze
+    CONFIRM_INTENT_TYPE = "Dialog.ConfirmIntent".freeze
+
+    class << self
+      def delegate_directive(updated_intents)
+        {
+          'type' => DELEGATE_TYPE,
+          'updatedIntent' => updated_intents
+        }
+      end
+
+      def elicit_slot_directive(slot, updated_intents)
+        {
+          'type' => ELICIT_SLOT_TYPE,
+          'slotToElicit' => slot,
+          'updatedIntent' => updated_intents
+        }
+      end
+
+      def confirm_slot_directive(slot, updated_intents)
+        {
+          'type' => CONFIRM_SLOT_TYPE,
+          'slotToConfirm' => slot,
+          'updatedIntent' => updated_intents
+        }
+      end
+
+      def confirm_intent_directive(updated_intents)
+        {
+          'type' => CONFIRM_INTENT_TYPE,
+          'updatedIntent' => updated_intents
+        }
+      end
+    end
+  end
+end

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -123,4 +123,12 @@ describe 'Builds appropriate response objects' do
     expect(response_json).to eq(sample_json)
   end
 
+  it 'should create a valid response when delegating the dialog to Alexa' do
+    response = AlexaRubykit::Response.new
+    response.delegate_dialog_response
+    response_object = response.build_response_object
+    expect(response_object).to include(:directives)
+    expect(response_object[:directives]).to include({'type' => 'Dialog.Delegate'})
+  end
+
 end


### PR DESCRIPTION
Hi Damian,

In my project, I've needed to support the new [Amazon Dialog API](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/ask-define-the-vui-with-gui#define-dialog), specifically the usage of delegating the dialog to alexa to handle the state of the conversation

Please review my pull request. If you will see some issues I'm ready to fix them.

Thanks!

Talha