### PR TITLE
Adding Response#add_audio_stop

### DIFF
--- a/fixtures/response-sessionAudioStop.json
+++ b/fixtures/response-sessionAudioStop.json
@@ -1,0 +1,12 @@
+{
+  "version" : "1.0",
+  "response" :
+  {
+    "directives": [
+      {
+        "type": "AudioPlayer.Stop"
+      }
+    ],
+    "shouldEndSession": true
+  }
+}

--- a/lib/alexa_rubykit/response.rb
+++ b/lib/alexa_rubykit/response.rb
@@ -39,6 +39,10 @@ module AlexaRubykit
       }
     end
 
+    def add_audio_stop
+      @directives << { 'type' => 'AudioPlayer.Stop' }
+    end
+
     def add_reprompt(speech_text, ssml = false)
       if ssml
         @reprompt = { "outputSpeech" => { :type => 'SSML', :ssml => check_ssml(speech_text) } }

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -123,4 +123,12 @@ describe 'Builds appropriate response objects' do
     expect(response_json).to eq(sample_json)
   end
 
+  it 'should create a valid response with an AudioPlayer.Stop directive' do
+    response = AlexaRubykit::Response.new
+    response.add_audio_stop
+    response.build_response_object
+    response_json = response.build_response
+    sample_json = JSON.parse(File.read('fixtures/response-sessionAudioStop.json')).to_json
+    expect(response_json).to eq(sample_json)
+  end
 end


### PR DESCRIPTION
Thank you for sharing this gem; it's been clear and straight-forward. Using the gem, I quickly had audio playing from my test device. But... I had no way to stop it (w/out leaving the app). 

This PR adds a method to stop audio. An example: 
```ruby
case input.name
when 'AMAZON.PauseIntent' then output.add_audio_stop
...
```

Let me know what you think.

Source: [Amazon docs](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/custom-audioplayer-interface-reference#stop) 