### PR TITLE
Added Dialog Functionality

### DIFF
--- a/fixtures/response-dialogConfirmIntentDirective.json
+++ b/fixtures/response-dialogConfirmIntentDirective.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0",
+  "response": {
+    "directives": [
+      {
+        "type": "Dialog.ConfirmIntent",
+        "updatedIntent": {
+          "name": "GetZodiacHoroscopeIntent",
+          "confirmationStatus": "NONE",
+          "slots": {
+            "City": {
+              "name": "City",
+              "confirmationStatus": "NONE"
+            },
+            "ZodiacSign": {
+              "name": "ZodiacSign",
+              "value": "virgo",
+              "confirmationStatus": "NONE"
+            }
+          }
+        }
+      }
+    ],
+  "shouldEndSession" :true
+  }
+}

--- a/fixtures/response-dialogConfirmSlotDirective.json
+++ b/fixtures/response-dialogConfirmSlotDirective.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0",
+  "response": {
+    "directives": [
+      {
+        "type": "Dialog.ConfirmSlot",
+        "slotToConfirm": "ZodiacSign",
+        "updatedIntent": {
+          "name": "GetZodiacHoroscopeIntent",
+          "confirmationStatus": "NONE",
+          "slots": {
+            "City": {
+              "name": "City",
+              "confirmationStatus": "NONE"
+            },
+            "ZodiacSign": {
+              "name": "ZodiacSign",
+              "value": "virgo",
+              "confirmationStatus": "NONE"
+            }
+          }
+        }
+      }
+    ],
+  "shouldEndSession" :true
+  }
+}

--- a/fixtures/response-dialogDelegateDirective.json
+++ b/fixtures/response-dialogDelegateDirective.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0",
+  "response": {
+    "directives": [
+      {
+        "type": "Dialog.Delegate",
+        "updatedIntent": {
+          "name": "GetZodiacHoroscopeIntent",
+          "confirmationStatus": "NONE",
+          "slots": {
+            "City": {
+              "name": "City",
+              "confirmationStatus": "NONE"
+            },
+            "ZodiacSign": {
+              "name": "ZodiacSign",
+              "value": "virgo",
+              "confirmationStatus": "NONE"
+            }
+          }
+        }
+      }
+    ],
+  "shouldEndSession" :true
+  }
+}

--- a/fixtures/response-dialogElicitSlotDirective.json
+++ b/fixtures/response-dialogElicitSlotDirective.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0",
+  "response": {
+    "directives": [
+      {
+        "type": "Dialog.ElicitSlot",
+        "slotToElicit": "City",
+        "updatedIntent": {
+          "name": "GetZodiacHoroscopeIntent",
+          "confirmationStatus": "NONE",
+          "slots": {
+            "City": {
+              "name": "City",
+              "confirmationStatus": "NONE"
+            },
+            "ZodiacSign": {
+              "name": "ZodiacSign",
+              "value": "virgo",
+              "confirmationStatus": "NONE"
+            }
+          }
+        }
+      }
+    ],
+  "shouldEndSession" :true
+  }
+}

--- a/fixtures/sample-Intent.json
+++ b/fixtures/sample-Intent.json
@@ -1,0 +1,15 @@
+{
+  "name": "GetZodiacHoroscopeIntent",
+  "confirmationStatus": "NONE",
+  "slots": {
+    "City": {
+      "name": "City",
+      "confirmationStatus": "NONE"
+    },
+    "ZodiacSign": {
+      "name": "ZodiacSign",
+      "value": "virgo",
+      "confirmationStatus": "NONE"
+    }
+  }
+}

--- a/fixtures/sample-IntentRequest.json
+++ b/fixtures/sample-IntentRequest.json
@@ -19,10 +19,12 @@
     "requestId": "amzn1.echo-api.request.6919844a-733e-4e89-893a-fdcb77e2ef0d",
     "intent": {
       "name": "GetZodiacHoroscopeIntent",
+      "confirmationStatus": "NONE",
       "slots": {
         "ZodiacSign": {
           "name": "ZodiacSign",
-          "value": "virgo"
+          "value": "virgo",
+          "confirmationStatus": "NONE"
         }
       }
     }

--- a/lib/alexa_rubykit/response.rb
+++ b/lib/alexa_rubykit/response.rb
@@ -24,7 +24,7 @@ module AlexaRubykit
       end
       @speech
     end
-    
+
     def add_audio_url(url, token='', offset=0)
       @directives << {
         'type' => 'AudioPlayer.Play',
@@ -39,6 +39,36 @@ module AlexaRubykit
       }
     end
 
+    def add_dialog_delegate_directive(intent:)
+      @directives << {
+        'type' => 'Dialog.Delegate',
+        'updatedIntent': intent
+      }
+    end
+
+    def add_dialog_elicit_slot_directive(slot_to_elicit:, intent:)
+      @directives << {
+        'type' => 'Dialog.ElicitSlot',
+        'slotToElicit': slot_to_elicit,
+        'updatedIntent': intent
+      }
+    end
+
+    def add_dialog_confirm_slot_directive(slot_to_confirm:, intent:)
+      @directives << {
+        'type' => 'Dialog.ConfirmSlot',
+        'slotToConfirm': slot_to_confirm,
+        'updatedIntent': intent
+      }
+    end
+
+    def add_dialog_confirm_intent_directive(intent:)
+      @directives << {
+        'type' => 'Dialog.ConfirmIntent',
+        'updatedIntent': intent
+      }
+    end
+
     def add_reprompt(speech_text, ssml = false)
       if ssml
         @reprompt = { "outputSpeech" => { :type => 'SSML', :ssml => check_ssml(speech_text) } }
@@ -48,7 +78,6 @@ module AlexaRubykit
       @reprompt
     end
 
-    #
     #"type": "string",
     #    "title": "string",
     #    "subtitle": "string",

--- a/lib/alexa_rubykit/version.rb
+++ b/lib/alexa_rubykit/version.rb
@@ -1,3 +1,3 @@
 module AlexaRubykit
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -113,7 +113,7 @@ describe 'Builds appropriate response objects' do
     sample_json = JSON.parse(File.read('fixtures/response-sessionAtt.json')).to_json
     expect(response_json).to eq(sample_json)
   end
-  
+
   it 'should create a valid response with an audio stream directive' do
     response = AlexaRubykit::Response.new
     response.add_audio_url('http://test/url.mp3','token',100)
@@ -122,5 +122,49 @@ describe 'Builds appropriate response objects' do
     sample_json = JSON.parse(File.read('fixtures/response-sessionAudio.json')).to_json
     expect(response_json).to eq(sample_json)
   end
+
+  it 'should create a valid response with a dialog delegate directive' do
+    response = AlexaRubykit::Response.new
+    intent = JSON.parse(File.read('fixtures/sample-Intent.json'))
+    response.add_dialog_delegate_directive(intent: intent)
+    response.build_response_object
+    response_json = response.build_response
+    sample_json = JSON.parse(File.read('fixtures/response-dialogDelegateDirective.json')).to_json
+    expect(response_json).to eq(sample_json)
+  end
+
+  it 'should create a valid response with a dialog confirm intent directive' do
+    response = AlexaRubykit::Response.new
+    intent = JSON.parse(File.read('fixtures/sample-Intent.json'))
+    response.add_dialog_confirm_intent_directive(intent: intent)
+    response.build_response_object
+    response_json = response.build_response
+    sample_json = JSON.parse(File.read('fixtures/response-dialogConfirmIntentDirective.json')).to_json
+    expect(response_json).to eq(sample_json)
+  end
+
+  it 'should create a valid response with a dialog confirm slot directive' do
+    response = AlexaRubykit::Response.new
+    intent = JSON.parse(File.read('fixtures/sample-Intent.json'))
+    response.add_dialog_confirm_slot_directive(slot_to_confirm: 'ZodiacSign', intent: intent)
+    response.build_response_object
+    response_json = response.build_response
+    sample_json = JSON.parse(File.read('fixtures/response-dialogConfirmSlotDirective.json')).to_json
+    puts ''
+    puts response_json
+    puts sample_json
+    expect(response_json).to eq(sample_json)
+  end
+
+  it 'should create a valid response with a dialog elicit slot directive' do
+    response = AlexaRubykit::Response.new
+    intent = JSON.parse(File.read('fixtures/sample-Intent.json'))
+    response.add_dialog_elicit_slot_directive(slot_to_elicit: 'City', intent: intent)
+    response.build_response_object
+    response_json = response.build_response
+    sample_json = JSON.parse(File.read('fixtures/response-dialogElicitSlotDirective.json')).to_json
+    expect(response_json).to eq(sample_json)
+  end
+
 
 end


### PR DESCRIPTION
I realized being able to send Dialog Directives had not yet been added into Alexa-rubykit. As this is something I want to include in my app, I took it upon myself to add them.

There are 4 distinct functions added to the response class, one for each type of dialog directive that can be given.

Tests are also included, they use the same formatting as the rest of the project. 