### PR TITLE
Create slot objects on initializing an intent request

### DIFF
--- a/lib/alexa_rubykit/intent_request.rb
+++ b/lib/alexa_rubykit/intent_request.rb
@@ -10,21 +10,22 @@ module AlexaRubykit
       raise ArgumentError, 'Intent should exist on an IntentRequest' if @intent.nil?
       @type = 'INTENT_REQUEST'
       @name  = @intent['name']
-      @slots = @intent['slots']
+      @slots = {}
+      add_slots(@intent['slots'])
     end
 
     # Takes a Hash object.
     def add_hash_slots(slots)
-      raise ArgumentError, 'Slots can\'t be empty'
-      slots.each do |slot|
-        @slots[:slot[:name]] = Slot.new(slot[:name], slot[:value])
+      raise ArgumentError, 'Slots can\'t be empty' if slots.empty?
+      slots.each do |name, slot|
+        @slots[name] = Slot.new(slot[:name], slot[:value])
       end
       @slots
     end
 
     # Takes a JSON Object and symbolizes its keys.
     def add_slots(slots)
-      slot_hash = AlexaRubykit.transform_keys_to_symbols(value)
+      slot_hash = AlexaRubykit.transform_keys_to_symbols(slots)
       add_hash_slots(slot_hash)
     end
 

--- a/spec/intent_request_spec.rb
+++ b/spec/intent_request_spec.rb
@@ -1,0 +1,37 @@
+require 'rspec'
+require 'alexa_rubykit'
+
+describe AlexaRubykit::IntentRequest do
+
+  let :json_request do
+    JSON.parse(File.read('fixtures/sample-IntentRequest.json'))
+  end
+
+  let :request do
+    AlexaRubykit.build_request(json_request)
+  end
+
+  it do
+    expect(request).to be_a(described_class)
+  end
+
+  context '#slots' do
+    let :slots do
+      request.slots
+    end
+
+    it do
+      expect(slots).to be_a(Hash)
+
+      expect(slots.size).to eq(1)
+
+      expect(slots).to have_key(:ZodiacSign)
+
+      expect(slots[:ZodiacSign]).to be_a(AlexaRubykit::Slot)
+
+      expect(slots[:ZodiacSign].name).to eq('ZodiacSign')
+
+      expect(slots[:ZodiacSign].value).to eq('virgo')
+    end
+  end
+end


### PR DESCRIPTION
Hi,

When an intent request was initialized, `@slots` of IntentRequest is a pure hash instance, but it should be a hash of `AlexaRubykit::Slot`.

This PR initializes `@slots` as a hash of `AlexaRubykit::Slot`.

Thanks!