### PR TITLE
Change dependency to permit Bundler 2.x use

### DIFF
--- a/alexa_rubykit.gemspec
+++ b/alexa_rubykit.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency 'bundler', '~> 1.7'
+  spec.add_runtime_dependency 'bundler', '~> 2.0'
   spec.add_runtime_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.2', '>= 3.2.0'
   spec.add_development_dependency 'rspec-mocks', '~> 3.2', '>= 3.2.0'


### PR DESCRIPTION
Hi,
I changed the bundler dependency to allow Bundler version 2.x usage.
Ian